### PR TITLE
Get vertex split records from decimator

### DIFF
--- a/examples/decimate.rb
+++ b/examples/decimate.rb
@@ -71,7 +71,7 @@ target = geometry.faces.count
 renderer.window.run do
   # Decimate by 0.1%
   target = (target * 0.995).floor
-  exit if target == 0
+  exit if target <= 500
   new_geometry, vertex_splits = decimator.decimate(target, vertex_splits: true)
   puts "f: #{new_geometry.faces.count}, v: #{new_geometry.vertices.count}"
   vertex_splits.each do |v|

--- a/examples/decimate.rb
+++ b/examples/decimate.rb
@@ -72,8 +72,11 @@ renderer.window.run do
   # Decimate by 0.1%
   target = (target * 0.995).floor
   exit if target == 0
-  new_geometry = decimator.decimate(target)
+  new_geometry, vertex_splits = decimator.decimate(target, vertex_splits: true)
   puts "f: #{new_geometry.faces.count}, v: #{new_geometry.vertices.count}"
+  vertex_splits.each do |v|
+    puts " - vsplit: #{v.vertex}, l: #{v.left}, r: #{v.right}, d: #{v.displacement.elements.inspect}"
+  end
 
   # Forcibly replace the geometry.
   # There might be a better way to do

--- a/lib/mittsu/mesh_analysis.rb
+++ b/lib/mittsu/mesh_analysis.rb
@@ -4,6 +4,7 @@ require "mittsu/mesh_analysis/face3"
 require "mittsu/mesh_analysis/analysis"
 require "mittsu/mesh_analysis/winged_edge_geometry"
 require "mittsu/mesh_analysis/modifiers/decimator"
+require "mittsu/mesh_analysis/vertex_split"
 
 module Mittsu
   class Object3D

--- a/lib/mittsu/mesh_analysis/modifiers/decimator.rb
+++ b/lib/mittsu/mesh_analysis/modifiers/decimator.rb
@@ -4,15 +4,21 @@ class Mittsu::MeshAnalysis::Decimator
     @geometry.from_geometry(geometry)
   end
 
-  def decimate(target_face_count)
+  def decimate(target_face_count, vertex_splits: false)
     @geometry.flatten!
     edge_collapses = edge_collapse_costs.sort_by { |x| x[:cost] }
+    splits = []
     loop do
       break if @geometry.faces.count <= target_face_count
       edge = edge_collapses.shift
-      @geometry.collapse(edge[:edge_index])
+      splits << @geometry.collapse(edge[:edge_index])
     end
-    @geometry
+    # Return vertex splits if requested
+    if vertex_splits
+      [@geometry, splits]
+    else
+      @geometry
+    end
   end
 
   def edge_collapse_costs

--- a/lib/mittsu/mesh_analysis/vertex_split.rb
+++ b/lib/mittsu/mesh_analysis/vertex_split.rb
@@ -1,0 +1,12 @@
+module Mittsu::MeshAnalysis
+  class VertexSplit
+    attr_accessor :vertex, :left, :right, :displacement
+
+    def initialize(vertex: nil, left: nil, right: nil, displacement: nil)
+      @vertex = vertex
+      @left = left
+      @right = right
+      @displacement = displacement
+    end
+  end
+end

--- a/lib/mittsu/mesh_analysis/winged_edge_geometry.rb
+++ b/lib/mittsu/mesh_analysis/winged_edge_geometry.rb
@@ -129,6 +129,9 @@ module Mittsu::MeshAnalysis
       e0 = edge(index)
       return if e0.nil?
 
+      # Create vertex split record
+      split = VertexSplit.new
+
       # Move vertices to new position
       new_position = Mittsu::Vector3.new(
         (@vertices[e0.start].x + @vertices[e0.finish].x) / 2,
@@ -182,7 +185,7 @@ module Mittsu::MeshAnalysis
       # Prepare for rendering
       flatten! if flatten
       # Return split parameters required to invert operation
-      # [vertex, left_vertex, right_vertex, displacement]
+      split
     end
 
     private

--- a/spec/lib/mittsu/mesh_analysis/decimator_spec.rb
+++ b/spec/lib/mittsu/mesh_analysis/decimator_spec.rb
@@ -12,4 +12,25 @@ RSpec.describe Mittsu::MeshAnalysis::Decimator do
     mesh.geometry = described_class.new(mesh.geometry).decimate(target)
     expect(mesh.geometry.faces.length).to be_within(1).of(target)
   end
+
+  context "when getting vertex splits back" do
+    let(:result) { described_class.new(mesh.geometry).decimate(mesh.geometry.faces.length * 0.5, vertex_splits: true) }
+
+    it "returns both geometry and split array" do # rubocop:disable RSpec/MultipleExpectations
+      geometry, splits = result
+      expect(geometry).to be_a Mittsu::Geometry
+      expect(splits).to be_a Array
+    end
+
+    it "has half as many splits as the number of faces that were removed" do
+      geometry, splits = result
+      removed = mesh.geometry.faces.length - geometry.faces.length
+      expect(splits.length).to eq removed / 2
+    end
+
+    it "creates vertex split objects" do
+      _geometry, splits = result
+      expect(splits[0]).to be_a Mittsu::MeshAnalysis::VertexSplit
+    end
+  end
 end

--- a/spec/lib/mittsu/mesh_analysis/vertex_split_spec.rb
+++ b/spec/lib/mittsu/mesh_analysis/vertex_split_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe Mittsu::MeshAnalysis::VertexSplit do
+  subject(:split) {
+    described_class.new(
+      vertex: 1, left: 2, right: 3,
+      displacement: Mittsu::Vector3.new(0.1, 0.2, 0.3)
+    )
+  }
+
+  it "has a vertex index" do
+    expect(split.vertex).to eq 1
+  end
+
+  it "has a left vertex index" do
+    expect(split.left).to eq 2
+  end
+
+  it "has a right vertex index" do
+    expect(split.right).to eq 3
+  end
+
+  it "has a displacement vector" do
+    expect(split.displacement).to eq Mittsu::Vector3.new(0.1, 0.2, 0.3)
+  end
+end

--- a/spec/lib/mittsu/mesh_analysis/winged_edge_geometry_spec.rb
+++ b/spec/lib/mittsu/mesh_analysis/winged_edge_geometry_spec.rb
@@ -122,4 +122,44 @@ RSpec.describe Mittsu::MeshAnalysis::WingedEdgeGeometry do
       expect(geometry).to be_manifold
     end
   end
+
+  context "when collapsing edges" do
+    let(:sphere) {
+      s = Mittsu::SphereGeometry.new(2.0, 32, 16)
+      s.merge_vertices
+      s
+    }
+
+    before do
+      geometry.from_geometry(sphere)
+    end
+
+    it "removes two faces when collapsing a single edge" do
+      expect { geometry.collapse(100) }.to change { geometry.faces.count }.by(-2)
+    end
+
+    context "when inspecting vertex split data" do
+      let(:split_data) { geometry.collapse(100) }
+
+      it "returns vertex index that needs splitting" do
+        expect(split_data.vertex).to eq 44
+      end
+
+      it "returns left vertex index" do
+        expect(split_data.left).to eq 12
+      end
+
+      it "returns right vertex index" do
+        expect(split_data.right).to eq 77
+      end
+
+      it "returns displacement vector" do
+        expect(split_data.displacement).to eq Mittsu::Vector3.new(
+          0.057990526381284435,
+          0,
+          -0.047591595070110015
+        )
+      end
+    end
+  end
 end

--- a/spec/lib/mittsu/mesh_analysis/winged_edge_geometry_spec.rb
+++ b/spec/lib/mittsu/mesh_analysis/winged_edge_geometry_spec.rb
@@ -154,11 +154,10 @@ RSpec.describe Mittsu::MeshAnalysis::WingedEdgeGeometry do
       end
 
       it "returns displacement vector" do
-        expect(split_data.displacement).to eq Mittsu::Vector3.new(
-          0.057990526381284435,
-          0,
-          -0.047591595070110015
-        )
+        expected = Mittsu::Vector3.new(0.057990, 0, -0.047592)
+        [:x, :y, :z].each do |axis|
+          expect(split_data.displacement.send(axis)).to be_within(1e-6).of expected.send(axis)
+        end
       end
     end
   end


### PR DESCRIPTION
Vertex splits can be used to reverse the decimation, which is a series of edge collapses; see https://en.wikipedia.org/wiki/Progressive_meshes