### PR TITLE
Re-order vertices during decimation

### DIFF
--- a/examples/decimate.rb
+++ b/examples/decimate.rb
@@ -69,9 +69,9 @@ decimator = Mittsu::MeshAnalysis::Decimator.new(geometry)
 target = geometry.faces.count
 
 renderer.window.run do
-  # Decimate by 0.1%
+  # Decimate by 0.5% per frame
   target = (target * 0.995).floor
-  exit if target <= 500
+  exit if target < 50
   new_geometry, vertex_splits = decimator.decimate(target, vertex_splits: true)
   puts "f: #{new_geometry.faces.count}, v: #{new_geometry.vertices.count}"
   vertex_splits.each do |v|

--- a/lib/mittsu/mesh_analysis/modifiers/decimator.rb
+++ b/lib/mittsu/mesh_analysis/modifiers/decimator.rb
@@ -9,13 +9,13 @@ class Mittsu::MeshAnalysis::Decimator
     edge_collapses = edge_collapse_costs.sort_by { |x| x[:cost] }
     splits = []
     loop do
-      break if @geometry.faces.count <= target_face_count
+      break if @geometry.faces.count <= target_face_count || edge_collapses.empty?
       edge = edge_collapses.shift
       splits.unshift @geometry.collapse(edge[:edge_index])
     end
     # Return vertex splits if requested
     if vertex_splits
-      [@geometry, splits]
+      [@geometry, splits.compact]
     else
       @geometry
     end

--- a/lib/mittsu/mesh_analysis/winged_edge.rb
+++ b/lib/mittsu/mesh_analysis/winged_edge.rb
@@ -98,26 +98,25 @@ module Mittsu::MeshAnalysis
     # Stitches another edge into this one
     # The edges must share a face and a vertex
     # The edge passed as an argument will be invalid
-    # Returns nil if not stiched, or the face index that might need
-    # an edge reference update if it was
-    def stitch!(edge)
+    # Returns the new edge, or nil if stitch failed
+    def stitch(edge)
       # Make sure the edges share a vertex and face
       face = shared_face(edge)
       return nil unless face && edge.coincident_at(edge)
       # Flip incoming edge if it's not pointing the same way
       edge = edge.flip unless same_direction?(edge)
       # Stitch left side of other edge if our left face is the shared one, or vice versa
+      stitched_edge = clone
       if face == @left
-        @start_left = edge.start_left
-        @finish_left = edge.finish_left
-        @left = edge.left
-        @left
+        stitched_edge.start_left = edge.start_left
+        stitched_edge.finish_left = edge.finish_left
+        stitched_edge.left = edge.left
       else
-        @start_right = edge.start_right
-        @finish_right = edge.finish_right
-        @right = edge.right
-        @right
+        stitched_edge.start_right = edge.start_right
+        stitched_edge.finish_right = edge.finish_right
+        stitched_edge.right = edge.right
       end
+      stitched_edge
     end
   end
 end

--- a/lib/mittsu/mesh_analysis/winged_edge.rb
+++ b/lib/mittsu/mesh_analysis/winged_edge.rb
@@ -31,27 +31,27 @@ module Mittsu::MeshAnalysis
     end
 
     def reattach_vertex(from:, to:)
-      out = nil
+      out = clone
       if @start == from
-        out = clone
         out.start = to
       elsif @finish == from
-        out = clone
         out.finish = to
       end
-      (out.nil? || out.degenerate?) ? nil : out
+      out
     end
 
-    def reattach_edge!(from:, to:)
-      if @start_left == from
-        @start_left = to
-      elsif @finish_left == from
-        @finish_left = to
-      elsif @start_right == from
-        @start_right = to
-      elsif @finish_right == from
-        @finish_right = to
+    def reattach_edge(from:, to:)
+      out = clone
+      if out.start_left == from
+        out.start_left = to
+      elsif out.finish_left == from
+        out.finish_left = to
+      elsif out.start_right == from
+        out.start_right = to
+      elsif out.finish_right == from
+        out.finish_right = to
       end
+      out
     end
 
     def coincident_at(edge)

--- a/lib/mittsu/mesh_analysis/winged_edge.rb
+++ b/lib/mittsu/mesh_analysis/winged_edge.rb
@@ -30,12 +30,16 @@ module Mittsu::MeshAnalysis
       (@start == index) ? @finish : @start
     end
 
-    def reattach_vertex!(from:, to:)
+    def reattach_vertex(from:, to:)
+      out = nil
       if @start == from
-        @start = to
+        out = clone
+        out.start = to
       elsif @finish == from
-        @finish = to
+        out = clone
+        out.finish = to
       end
+      (out.nil? || out.degenerate?) ? nil : out
     end
 
     def reattach_edge!(from:, to:)

--- a/lib/mittsu/mesh_analysis/winged_edge_geometry.rb
+++ b/lib/mittsu/mesh_analysis/winged_edge_geometry.rb
@@ -142,7 +142,7 @@ module Mittsu::MeshAnalysis
       changeset = {
         e0.index => nil,
         e0.finish_left => nil,
-        e0.start_right => nil
+        e0.finish_right => nil
       }
 
       # Collapse left face
@@ -158,9 +158,9 @@ module Mittsu::MeshAnalysis
       start = @edges[e0.start_right]
       finish = @edges[e0.finish_right]
       if start && finish
-        split.right = finish.other_vertex(e0.start)
-        finish = finish.stitch(start)
-        @edges[finish.index] = finish
+        split.right = start.other_vertex(e0.start)
+        start = start.stitch(finish)
+        @edges[start.index] = start
       end
 
       # Reattach edges to remove old indexes
@@ -172,7 +172,7 @@ module Mittsu::MeshAnalysis
       @edges.each do |e|
         next if e.nil?
         e.reattach_edge!(from: finish_left.index, to: start_left.index) if finish_left && start_left
-        e.reattach_edge!(from: start_right.index, to: finish_right.index) if finish_right && start_right
+        e.reattach_edge!(from: finish_right.index, to: start_right.index) if finish_right && start_right
         reattached = e.reattach_vertex(from: e0.finish, to: e0.start)
         @edges[reattached.index] = reattached if reattached
       end

--- a/lib/mittsu/mesh_analysis/winged_edge_geometry.rb
+++ b/lib/mittsu/mesh_analysis/winged_edge_geometry.rb
@@ -163,7 +163,8 @@ module Mittsu::MeshAnalysis
         next if e.nil?
         e.reattach_edge!(from: finish_left.index, to: start_left.index) if finish_left && start_left
         e.reattach_edge!(from: start_right.index, to: finish_right.index) if finish_right && start_right
-        e.reattach_vertex!(from: e0.finish, to: e0.start) if e0
+        r = e.reattach_vertex(from: e0.finish, to: e0.start)
+        @edges[e.index] = r if r
       end
 
       # Prepare for rendering

--- a/lib/mittsu/mesh_analysis/winged_edge_geometry.rb
+++ b/lib/mittsu/mesh_analysis/winged_edge_geometry.rb
@@ -131,13 +131,12 @@ module Mittsu::MeshAnalysis
       end
 
       # Create vertex split record
-      split = VertexSplit.new(vertex: e0.start)
-
-      # Calculate displacement vector and move old vertex
-      split.displacement = Mittsu::Vector3.new
-      split.displacement.sub_vectors(@vertices[e0.finish], @vertices[e0.start])
-      split.displacement.divide_scalar(2)
-      @vertices[e0.start].add(split.displacement)
+      split = VertexSplit.new(
+        vertex: e0.start,
+        left: edge(e0.start_left)&.other_vertex(e0.start),
+        right: edge(e0.start_right)&.other_vertex(e0.start),
+        displacement: Mittsu::Vector3.new.sub_vectors(@vertices[e0.finish], @vertices[e0.start]).divide_scalar(2)
+      )
 
       # Collapse left face
       start_left = @edges[e0.start_left]
@@ -173,6 +172,8 @@ module Mittsu::MeshAnalysis
         @edges[e.index] = r if r
       end
 
+      # Move vertex
+      @vertices[e0.start] = Mittsu::Vector3.new.add_vectors(@vertices[e0.start], split.displacement)
       # Prepare for rendering
       flatten! if flatten
       # Return split parameters required to invert operation

--- a/lib/mittsu/mesh_analysis/winged_edge_geometry.rb
+++ b/lib/mittsu/mesh_analysis/winged_edge_geometry.rb
@@ -146,25 +146,29 @@ module Mittsu::MeshAnalysis
       }
 
       # Collapse left face
-      start_left = @edges[e0.start_left]
-      finish_left = @edges[e0.finish_left]
-      if start_left && finish_left
-        split.left = start_left.other_vertex(e0.start)
-        start_left = start_left.stitch(finish_left)
-        @edges[start_left.index] = start_left
+      start = @edges[e0.start_left]
+      finish = @edges[e0.finish_left]
+      if start && finish
+        split.left = start.other_vertex(e0.start)
+        start = start.stitch(finish)
+        @edges[start.index] = start
       end
 
       # Collapse right face
-      start_right = @edges[e0.start_right]
-      finish_right = @edges[e0.finish_right]
-      if start_right && finish_right
-        split.right = finish_right.other_vertex(e0.start)
-        finish_right = finish_right.stitch(start_right)
-        @edges[finish_right.index] = finish_right
+      start = @edges[e0.start_right]
+      finish = @edges[e0.finish_right]
+      if start && finish
+        split.right = finish.other_vertex(e0.start)
+        finish = finish.stitch(start)
+        @edges[finish.index] = finish
       end
 
       # Reattach edges to remove old indexes
       # This could be much more efficient by walking round the wings
+      start_left = @edges[e0.start_left]
+      finish_left = @edges[e0.finish_left]
+      start_right = @edges[e0.start_right]
+      finish_right = @edges[e0.finish_right]
       @edges.each do |e|
         next if e.nil?
         e.reattach_edge!(from: finish_left.index, to: start_left.index) if finish_left && start_left

--- a/lib/mittsu/mesh_analysis/winged_edge_geometry.rb
+++ b/lib/mittsu/mesh_analysis/winged_edge_geometry.rb
@@ -120,9 +120,15 @@ module Mittsu::MeshAnalysis
     # and merging everything onto the start vertex instead.
     # If the result would be degenerate in some way, the mesh is unchanged
     def collapse(index, flatten: true)
-      # find the edge
+      # Find edge, reorder vertices and reload
       e0 = edge(index)
-      return if e0.nil?
+      if e0
+        move_vertex_to_end(e0.finish)
+        e0 = edge(index)
+      else
+        # Invalid edge index
+        return nil
+      end
 
       # Create vertex split record
       split = VertexSplit.new(vertex: e0.start)

--- a/lib/mittsu/mesh_analysis/winged_edge_geometry.rb
+++ b/lib/mittsu/mesh_analysis/winged_edge_geometry.rb
@@ -138,7 +138,7 @@ module Mittsu::MeshAnalysis
       finish_left = @edges[e0.finish_left]
       if start_left && finish_left
         split.left = start_left.other_vertex(e0.start)
-        start_left.stitch!(finish_left)
+        start_left = start_left.stitch(finish_left)
         @edges[start_left.index] = start_left
       end
 
@@ -147,7 +147,7 @@ module Mittsu::MeshAnalysis
       finish_right = @edges[e0.finish_right]
       if start_right && finish_right
         split.right = finish_right.other_vertex(e0.start)
-        finish_right.stitch!(start_right)
+        finish_right = finish_right.stitch(start_right)
         @edges[finish_right.index] = finish_right
       end
 

--- a/lib/mittsu/mesh_analysis/winged_edge_geometry.rb
+++ b/lib/mittsu/mesh_analysis/winged_edge_geometry.rb
@@ -174,12 +174,13 @@ module Mittsu::MeshAnalysis
     end
 
     def move_vertex_to_end(index)
-      return if index >= @vertices.count
+      return unless @vertices[index]
       # Add move vertex to end of array
       @vertices.push @vertices.slice!(index)
       new_index = @vertices.count - 1
       # Update all vertex references
       @edges.each do |edge|
+        next if edge.nil?
         if edge.start == index
           edge.start = new_index
         elsif edge.start > index

--- a/lib/mittsu/mesh_analysis/winged_edge_geometry.rb
+++ b/lib/mittsu/mesh_analysis/winged_edge_geometry.rb
@@ -155,10 +155,10 @@ module Mittsu::MeshAnalysis
       # This could be much more efficient by walking round the wings
       @edges.each do |e|
         next if e.nil? || e.index == e0.index
-        e.reattach_edge!(from: e0.finish_left, to: e0.start_left)
-        e.reattach_edge!(from: e0.finish_right, to: e0.start_right)
-        reattached = e.reattach_vertex(from: e0.finish, to: e0.start)
-        @edges[reattached.index] = reattached if reattached
+        @edges[e.index] =
+          e.reattach_edge(from: e0.finish_left, to: e0.start_left)
+            .reattach_edge(from: e0.finish_right, to: e0.start_right)
+            .reattach_vertex(from: e0.finish, to: e0.start)
       end
 
       # Apply edge changes

--- a/spec/lib/mittsu/mesh_analysis/winged_edge_geometry_spec.rb
+++ b/spec/lib/mittsu/mesh_analysis/winged_edge_geometry_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe Mittsu::MeshAnalysis::WingedEdgeGeometry do
       end
 
       it "returns right vertex index" do
-        expect(split_data.right).to eq 76
+        expect(split_data.right).to eq 481
       end
 
       it "returns displacement vector" do

--- a/spec/lib/mittsu/mesh_analysis/winged_edge_geometry_spec.rb
+++ b/spec/lib/mittsu/mesh_analysis/winged_edge_geometry_spec.rb
@@ -138,6 +138,11 @@ RSpec.describe Mittsu::MeshAnalysis::WingedEdgeGeometry do
       expect { geometry.collapse(100) }.to change { geometry.faces.count }.by(-2)
     end
 
+    it "removes one vertex when collapsing a single edge" do
+      pending "awaiting implementation of vertex compaction"
+      expect { geometry.collapse(100) }.to change { geometry.vertices.count }.by(-1)
+    end
+
     context "when inspecting vertex split data" do
       let(:split_data) { geometry.collapse(100) }
 

--- a/spec/lib/mittsu/mesh_analysis/winged_edge_geometry_spec.rb
+++ b/spec/lib/mittsu/mesh_analysis/winged_edge_geometry_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Mittsu::MeshAnalysis::WingedEdgeGeometry do
       end
 
       it "returns right vertex index" do
-        expect(split_data.right).to eq 77
+        expect(split_data.right).to eq 76
       end
 
       it "returns displacement vector" do

--- a/spec/lib/mittsu/mesh_analysis/winged_edge_spec.rb
+++ b/spec/lib/mittsu/mesh_analysis/winged_edge_spec.rb
@@ -42,16 +42,21 @@ RSpec.describe Mittsu::MeshAnalysis::WingedEdge do
     expect(edge.other_vertex(2)).to eq 1
   end
 
-  it "can reattach start to a different vertex" do
-    expect { edge.reattach_vertex!(from: 1, to: 3) }.to change(edge, :start).from(1).to(3).and change(edge, :finish).by(0) # rubocop:todo RSpec/ChangeByZero
+  it "can reattach start to a different vertex" do # rubocop:disable RSpec/MultipleExpectations
+    new_edge = edge.reattach_vertex(from: 1, to: 3)
+    expect(new_edge.start).to eq 3
+    expect(new_edge.finish).to eq 2
   end
 
-  it "can reattach end to a different vertex" do
-    expect { edge.reattach_vertex!(from: 2, to: 3) }.to change(edge, :finish).from(2).to(3).and change(edge, :start).by(0) # rubocop:todo RSpec/ChangeByZero
+  it "can reattach end to a different vertex" do # rubocop:disable RSpec/MultipleExpectations
+    new_edge = edge.reattach_vertex(from: 2, to: 3)
+    expect(new_edge.start).to eq 1
+    expect(new_edge.finish).to eq 3
   end
 
   it "does not change unattached vertices" do
-    expect { edge.reattach_vertex!(from: 5, to: 3) }.to change(edge, :start).by(0).and change(edge, :finish).by(0) # rubocop:todo RSpec/ChangeByZero
+    new_edge = edge.reattach_vertex(from: 5, to: 3)
+    expect(new_edge).to be_nil
   end
 
   context "when testing for duplication with #colinear?" do

--- a/spec/lib/mittsu/mesh_analysis/winged_edge_spec.rb
+++ b/spec/lib/mittsu/mesh_analysis/winged_edge_spec.rb
@@ -54,9 +54,10 @@ RSpec.describe Mittsu::MeshAnalysis::WingedEdge do
     expect(new_edge.finish).to eq 3
   end
 
-  it "does not change unattached vertices" do
+  it "does not change unattached vertices" do # rubocop:disable RSpec/MultipleExpectations
     new_edge = edge.reattach_vertex(from: 5, to: 3)
-    expect(new_edge).to be_nil
+    expect(new_edge.start).to eq 1
+    expect(new_edge.finish).to eq 2
   end
 
   context "when testing for duplication with #colinear?" do


### PR DESCRIPTION
Required so that we can output proper progressive streams, and not leave gaps in our vertex list. Resolves #10.

This still has errors with non-manifold meshes being created, but that's covered by #4 